### PR TITLE
Add missing io.hass.* labels, change type to "app"

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -19,6 +19,9 @@ jobs:
       architectures: ${{ steps.info.outputs.architectures }}
       build_matrix: ${{ steps.matrix.outputs.matrix }}
       image_name: ${{ steps.normalize.outputs.image_name }}
+      name: ${{ steps.normalize.outputs.name }}
+      description: ${{ steps.normalize.outputs.description }}
+      url: ${{ steps.normalize.outputs.url }}
       registry_prefix: ${{ steps.normalize.outputs.registry_prefix }}
       version: ${{ steps.normalize.outputs.version }}
     steps:
@@ -34,12 +37,19 @@ jobs:
       - name: Normalize app information
         id: normalize
         run: |
-          image="${{ steps.info.outputs.image }}"
+          image=${{ steps.info.outputs.image }}
           echo "image_name=${image##*/}" >> "$GITHUB_OUTPUT"
           echo "registry_prefix=${image%/*}" >> "$GITHUB_OUTPUT"
-          # Strip surrounding quotes that the info action includes from YAML string values
-          version="${{ steps.info.outputs.version }}"
-          echo "version=${version//[\"\']/}" >> "$GITHUB_OUTPUT"
+          version=${{ steps.info.outputs.version }}
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          name=${{ steps.info.outputs.name }}
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          description=${{ steps.info.outputs.description }}
+          echo "description=${description}" >> "$GITHUB_OUTPUT"
+          url=${{ steps.info.outputs.url }}
+          if [[ -n "$url" && "$url" != "null" ]]; then
+            echo "url=${url}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Prepare build matrix
         id: matrix
@@ -76,6 +86,11 @@ jobs:
           image-tags: |
             ${{ needs.prepare.outputs.version }}
             latest
+          labels: |
+            io.hass.type=app
+            io.hass.name=${{ needs.prepare.outputs.name }}
+            io.hass.description=${{ needs.prepare.outputs.description }}
+            ${{ needs.prepare.outputs.url && format('io.hass.url={0}', needs.prepare.outputs.url) || '' }}
           push: ${{ inputs.publish }}
           version: ${{ needs.prepare.outputs.version }}
 

--- a/example/CHANGELOG.md
+++ b/example/CHANGELOG.md
@@ -1,4 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/apps/presentation#keeping-a-changelog -->
+## 1.3.1
+
+* Rebuild with updated workflow to include `io.hass.*` labels.
+* Remove io.hass.type from Dockerfile, let build add it (with "app" value).
+
 ## 1.3.0
 
 - Updated to Alpine 3.23 base image.

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -21,7 +21,6 @@ RUN \
 COPY rootfs /
 
 LABEL \
-    io.hass.type="addon" \
     org.opencontainers.image.title="Home Assistant App: Example app" \
     org.opencontainers.image.description="Example app to use as a blueprint for new apps." \
     org.opencontainers.image.source="https://github.com/home-assistant/apps-example" \

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/apps/configuration#app-configuration
 name: Example app
-version: "1.3.0"
+version: "1.3.1"
 slug: example
 description: Example app
 url: "https://github.com/home-assistant/apps-example/tree/main/example"


### PR DESCRIPTION
The legacy builder was adding couple of more labels read from the config, add them in the updated workflow too. Also, change the type label from "addon" to "app" to match changes in other places.

The quotes for the values from the info action are now removed by shell expansion instead of the heavy-handed replace expression.