### PR TITLE
Bump devcontainer to 5-apps

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,7 +9,8 @@
   "workspaceFolder": "/mnt/supervisor/addons/local/${localWorkspaceFolderBasename}",
   "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=cached",
   "containerEnv": {
-    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}"
+    "WORKSPACE_DIRECTORY": "${containerWorkspaceFolder}",
+    "SUPERVISOR_CHANNEL": "beta"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Example devcontainer for apps repositories",
-  "image": "ghcr.io/home-assistant/devcontainer:4-apps",
+  "image": "ghcr.io/home-assistant/devcontainer:5-apps",
   "overrideCommand": false,
   "remoteUser": "vscode",
   "appPort": ["7123:8123", "7357:4357"],


### PR DESCRIPTION
Changes:
- Bind-mount /run/supervisor into the Supervisor container so the Home Assistant Core bind mount of the same path works (fixes "bind source path does not exist: /run/supervisor")
- Drop WSL2 iptables-legacy workaround; recent WSL2 kernels (e.g. 6.6.87.2-microsoft-standard-WSL2) handle the nft backend natively

Fixes home-assistant/devcontainer#165